### PR TITLE
added early stop callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,11 +331,24 @@ The default configuration parameters used by the Mango as below:
  'num_iteration': 20,
  'batch_size': 1}
 ```
-The configuration parameters are explained:
+The configuration parameters are:
 - domain_size: The size which is explored in each iteration by the gaussian process. Generally, a larger size is preferred if higher dimensional functions are optimized. More on this will be added with details about the internals of bayesian optimization.
 - initial_random: The number of random samples tried.
 - num_iteration: The total number of iterations used by Mango to find the optimal value.
 - batch_size: The size of args_list passed to the objective function for parallel evaluation. For larger batch sizes, Mango internally uses intelligent sampling to decide the optimal samples to evaluate.
+- early_stopping: A callback to specify custom stopping criteria. The callback has the following signature:
+   ```python
+  def early_stopping(results):
+      '''
+          results is the same as dict returned by tuner
+          keys available: params_tries, objective_values, 
+              best_objective, best_params
+      '''
+      ...
+      return True/False
+  ```
+  For usage see early stopping examples [notebook]((https://github.com/ARM-software/mango/blob/master/examples/EarlyStopping.ipynb)).
+
 
 The default configuration parameters can be modified, as shown below. Only the parameters whose values need to adjusted can be passed as the dictionary.
 
@@ -344,6 +357,7 @@ conf_dict = dict(num_iteration=40, domain_size=10000, initial_random=3)
 
 tuner = Tuner(param_dict, objective, conf_dict) 
 ```
+
 
 <!--
 <a name="Celery"></a>

--- a/examples/EarlyStopping.ipynb
+++ b/examples/EarlyStopping.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "promising-google",
+   "metadata": {},
+   "source": [
+    "## Early stopping callback"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "political-complexity",
+   "metadata": {},
+   "source": [
+    "### stop if objective function is below a certain threshold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "needed-adapter",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "70bcc0e298c44cb190dce802a7d1ad57",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'random_params': array([{'x': -6}, {'x': -2}], dtype=object),\n",
+       " 'random_params_objective': array([-36,  -4]),\n",
+       " 'params_tried': array([{'x': -6}, {'x': -2}, {'x': -3}, {'x': 3}, {'x': 0}], dtype=object),\n",
+       " 'objective_values': array([36,  4,  9,  9,  0]),\n",
+       " 'surrogate_values': array([-36.,  -4.,   0.,   0.,   0.]),\n",
+       " 'best_objective': 0,\n",
+       " 'best_params': {'x': 0}}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from mango import Tuner\n",
+    "\n",
+    "param_dict = dict(x=range(-10, 10))\n",
+    "\n",
+    "def objfunc(p_list):\n",
+    "    return [p['x'] ** 2 for p in p_list]\n",
+    "\n",
+    "def early_stop(results):\n",
+    "    '''\n",
+    "        stop if best objective is below 2\n",
+    "        results: dict (same keys as dict returned by tuner.minimize/maximize)\n",
+    "    '''\n",
+    "    return results['best_objective'] <= 2\n",
+    "\n",
+    "config = dict(early_stopping=early_stop)\n",
+    "\n",
+    "tuner = Tuner(param_dict, objfunc, conf_dict=config)\n",
+    "results = tuner.minimize()\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "phantom-elevation",
+   "metadata": {},
+   "source": [
+    "### stop if objective function does not improve for n iterations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "identical-chile",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e68c253938fc4b2b85f5576393d2c55f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'random_params': array([{'x': 7}, {'x': -4}], dtype=object),\n",
+       " 'random_params_objective': array([-49, -16]),\n",
+       " 'params_tried': array([{'x': 7}, {'x': -4}, {'x': -2}, {'x': -4}, {'x': -1}, {'x': -10},\n",
+       "        {'x': 6}, {'x': -1}, {'x': 6}, {'x': 2}, {'x': 0}, {'x': 1},\n",
+       "        {'x': 3}, {'x': -9}], dtype=object),\n",
+       " 'objective_values': array([ 49,  16,   4,  16,   1, 100,  36,   1,  36,   4,   0,   1,   9,\n",
+       "         81]),\n",
+       " 'surrogate_values': array([-4.90000000e+01, -1.60000000e+01,  0.00000000e+00,  0.00000000e+00,\n",
+       "         0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,\n",
+       "         0.00000000e+00, -3.25445372e+00, -4.75155392e-02, -1.19646246e+00,\n",
+       "        -8.63547743e+00, -8.95304193e+01]),\n",
+       " 'best_objective': 0,\n",
+       " 'best_params': {'x': 0}}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from mango import Tuner\n",
+    "\n",
+    "param_dict = dict(x=range(-10, 10))\n",
+    "\n",
+    "def objfunc(p_list):\n",
+    "    return [p['x'] ** 2 for p in p_list]\n",
+    "    \n",
+    "\n",
+    "def early_stop(results):\n",
+    "    '''\n",
+    "        stop if best objective does not improve for 2 iterations\n",
+    "        results: dict (same keys as dict returned by tuner.minimize/maximize)\n",
+    "    '''\n",
+    "    current_best = results['best_objective']\n",
+    "    patience_window = results['objective_values'][-3:]\n",
+    "    return min(patience_window) > current_best\n",
+    "\n",
+    "config = dict(early_stopping=early_stop)\n",
+    "\n",
+    "tuner = Tuner(param_dict, objfunc, conf_dict=config)\n",
+    "results = tuner.minimize()\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "stuffed-hearts",
+   "metadata": {},
+   "source": [
+    "### stop if objective function does not improve for n secs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "express-ability",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fed303e6d4044f09a3cff610203755b1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "no improvement in 0.100000 seconds: stopping early.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'random_params': array([{'x': 5}, {'x': -3}], dtype=object),\n",
+       " 'random_params_objective': array([-25,  -9]),\n",
+       " 'params_tried': array([{'x': 5}, {'x': -3}, {'x': 4}, {'x': 9}], dtype=object),\n",
+       " 'objective_values': array([25,  9, 16, 81]),\n",
+       " 'surrogate_values': array([-25.,  -9.,   0.,   0.]),\n",
+       " 'best_objective': 9,\n",
+       " 'best_params': {'x': -3}}"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import time\n",
+    "import numpy as np\n",
+    "\n",
+    "from mango import Tuner\n",
+    "\n",
+    "param_dict = dict(x=range(-10, 10))\n",
+    "\n",
+    "def objfunc(p_list):\n",
+    "    time.sleep(0.5)\n",
+    "    return [p['x'] ** 2 for p in p_list]\n",
+    "    \n",
+    "\n",
+    "class context:\n",
+    "    previous_best = None\n",
+    "    previous_best_time = None\n",
+    "    min_improvement_secs = 0.1\n",
+    "    \n",
+    "\n",
+    "def early_stop(results):\n",
+    "    '''\n",
+    "        stop if objective does not improve for 0.1 seconds\n",
+    "    '''\n",
+    "    current_best = results['best_objective']\n",
+    "    current_time = time.time()\n",
+    "    \n",
+    "    _stop = False\n",
+    "\n",
+    "    if context.previous_best is None:\n",
+    "        context.previous_best = current_best\n",
+    "        context.previous_best_time = current_time\n",
+    "        \n",
+    "    elif current_best == context.previous_best and \\\n",
+    "            (current_time - context.previous_best_time > context.min_improvement_secs):\n",
+    "        print(\"no improvement in %f seconds: stopping early.\" % context.min_improvement_secs)\n",
+    "        _stop = True\n",
+    "        \n",
+    "    else:\n",
+    "        context.previous_best = current_best\n",
+    "        context.previous_best_time = current_time\n",
+    "\n",
+    "    return _stop\n",
+    "\n",
+    "config = dict(early_stopping=early_stop)\n",
+    "\n",
+    "tuner = Tuner(param_dict, objfunc, conf_dict=config)\n",
+    "results = tuner.minimize()\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "alpine-drilling",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mango/tuner.py
+++ b/mango/tuner.py
@@ -42,7 +42,6 @@ class Tuner:
         exploration_min: float = 0.1
         fixed_domain: bool = False
         early_stopping: Callable = None
-        _early_stop_context: object = None
 
         def __post_init__(self):
             if self.optimizer not in self.valid_optimizers:
@@ -72,8 +71,7 @@ class Tuner:
                 return False
 
             results = copy.deepcopy(results)
-            out, self._early_stop_context = self.early_stopping(results, context=self._early_stop_context)
-            return out
+            return self.early_stopping(results)
 
     def __init__(self, param_dict, objective, conf_dict=None):
 

--- a/tests/test_tuner.py
+++ b/tests/test_tuner.py
@@ -368,6 +368,7 @@ def test_early_stopping_complex():
 
         current_best = results['best_objective']
         current_time = time.time()
+        _stop = False
 
         if context.previous_best is None:
             context.previous_best = current_best
@@ -375,12 +376,12 @@ def test_early_stopping_complex():
         elif (current_best <= context.previous_best + context.objective_variation) and \
                 (current_time - context.previous_best_time > context.min_improvement_secs):
             print("no improvement in %d seconds: stopping early." % context.min_improvement_secs)
-            return True, context
+            _stop = True
         else:
             context.previous_best = current_best
             context.previous_best_time = current_time
 
-        return False, context
+        return _stop, context
 
     config = dict(num_iteration=20, initial_random=1, early_stopping=early_stop)
 

--- a/tests/test_tuner.py
+++ b/tests/test_tuner.py
@@ -8,7 +8,6 @@ $  python -m pytest tests/ --disable-warnings
 """
 import math
 import time
-from dataclasses import dataclass
 from pytest import approx
 import numpy as np
 
@@ -357,7 +356,6 @@ def test_early_stopping_complex():
         res = [np.random.uniform()] * len(p_list)
         return res
 
-    @dataclass
     class Context:
         previous_best = None
         previous_best_time = None
@@ -368,14 +366,13 @@ def test_early_stopping_complex():
         if context is None:
             context = Context()
 
-        previous_best = context.previous_best
         current_best = results['best_objective']
         current_time = time.time()
 
-        if previous_best is None:
+        if context.previous_best is None:
             context.previous_best = current_best
             context.previous_best_time = current_time
-        elif (current_best <= previous_best + context.objective_variation) and \
+        elif (current_best <= context.previous_best + context.objective_variation) and \
                 (current_time - context.previous_best_time > context.min_improvement_secs):
             print("no improvement in %d seconds: stopping early." % context.min_improvement_secs)
             return True, context

--- a/tests/test_tuner.py
+++ b/tests/test_tuner.py
@@ -330,10 +330,9 @@ def test_early_stopping_simple():
     def objfunc(p_list):
         return [p['x'] ** 2 for p in p_list]
 
-    def early_stop(results, context=None):
+    def early_stop(results):
         if len(results['params_tried']) >= 5:
-            return True, context
-        return False, context
+            return True
 
     config = dict(num_iteration=20, initial_random=1, early_stopping=early_stop)
 
@@ -362,9 +361,8 @@ def test_early_stopping_complex():
         min_improvement_secs = 1
         objective_variation = 1
 
-    def early_stop(results, context=None):
-        if context is None:
-            context = Context()
+    def early_stop(results):
+        context = Context
 
         current_best = results['best_objective']
         current_time = time.time()
@@ -381,10 +379,10 @@ def test_early_stopping_complex():
             context.previous_best = current_best
             context.previous_best_time = current_time
 
-        return _stop, context
+        return _stop
 
     config = dict(num_iteration=20, initial_random=1, early_stopping=early_stop)
 
     tuner = Tuner(param_dict, objfunc, conf_dict=config)
     results = tuner.minimize()
-    assert (len(results['params_tried']) <= 3)
+    assert (len(results['params_tried']) == 3)


### PR DESCRIPTION
Added `early_stopping` callback to allow custom logic for stopping criteria. See `test_tuner.test_early_stopping_complex` for usage example that @asah requested. Will add them to readme once PR is approved.

closes #19 